### PR TITLE
fix: convert custom model rolls map to use string key

### DIFF
--- a/src/main/java/xyz/iwolfking/vhapi/api/data/api/CustomGearModelRolls.java
+++ b/src/main/java/xyz/iwolfking/vhapi/api/data/api/CustomGearModelRolls.java
@@ -8,5 +8,5 @@ import java.util.List;
 import java.util.Map;
 
 public class CustomGearModelRolls {
-    public static final Map<ResourceLocation, Map<VaultGearRarity, List<String>>> CUSTOM_MODEL_ROLLS_MAP = new HashMap<>();
+    public static final Map<ResourceLocation, Map<String, List<String>>> CUSTOM_MODEL_ROLLS_MAP = new HashMap<>();
 }

--- a/src/main/java/xyz/iwolfking/vhapi/api/loaders/gear/transmog/CustomGearModelRollRaritiesConfigLoader.java
+++ b/src/main/java/xyz/iwolfking/vhapi/api/loaders/gear/transmog/CustomGearModelRollRaritiesConfigLoader.java
@@ -20,11 +20,11 @@ public class CustomGearModelRollRaritiesConfigLoader extends VaultConfigProcesso
         for(CustomGearModelRollRaritiesConfig config : this.CUSTOM_CONFIGS.values()) {
             if(CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.containsKey(config.itemRegistryName)) {
                 for(VaultGearRarity rarity : VaultGearRarity.values()) {
-                    if(CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).containsKey(rarity)){
-                        CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).get(rarity).addAll(config.MODEL_ROLLS.get(rarity));
+                    if(CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).containsKey(rarity.name())){
+                        CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).get(rarity.name()).addAll(config.MODEL_ROLLS.get(rarity));
                     }
                     else {
-                        CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).put(rarity, config.MODEL_ROLLS.get(rarity));
+                        CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(config.itemRegistryName).put(rarity.name(), config.MODEL_ROLLS.get(rarity));
                     }
                 }
             }

--- a/src/main/java/xyz/iwolfking/vhapi/api/loaders/gear/transmog/lib/CustomGearModelRollRaritiesConfig.java
+++ b/src/main/java/xyz/iwolfking/vhapi/api/loaders/gear/transmog/lib/CustomGearModelRollRaritiesConfig.java
@@ -14,7 +14,7 @@ public class CustomGearModelRollRaritiesConfig extends Config {
     public ResourceLocation itemRegistryName;
 
     @Expose
-    public Map<VaultGearRarity, List<String>> MODEL_ROLLS;
+    public Map<String, List<String>> MODEL_ROLLS;
     @Override
     public String getName() {
         return "custom_gear_model_roll_rarities";

--- a/src/main/java/xyz/iwolfking/vhapi/api/registry/gear/CustomVaultGearRegistryEntry.java
+++ b/src/main/java/xyz/iwolfking/vhapi/api/registry/gear/CustomVaultGearRegistryEntry.java
@@ -19,7 +19,7 @@ public class CustomVaultGearRegistryEntry extends ForgeRegistryEntry<CustomVault
 
     private final DynamicModelRegistry<?> dynamicModelRegistry;
 
-    private final Map<VaultGearRarity, List<String>> modelRarityMap;
+    private final Map<String, List<String>> modelRarityMap;
 
     /**
      *
@@ -29,7 +29,7 @@ public class CustomVaultGearRegistryEntry extends ForgeRegistryEntry<CustomVault
      * @param dynamicModelRegistry A registry that will contain all of the transmog models for the gear piece.
      * @param modelRarityMap A map of VaultGearRarity to a list of transmog model names.
      */
-    public CustomVaultGearRegistryEntry(String id, String name, @NotNull Item registryItem, DynamicModelRegistry<?> dynamicModelRegistry, Map<VaultGearRarity, List<String>> modelRarityMap) {
+    public CustomVaultGearRegistryEntry(String id, String name, @NotNull Item registryItem, DynamicModelRegistry<?> dynamicModelRegistry, Map<String, List<String>> modelRarityMap) {
         this.name = name;
         this.registryItem = registryItem;
         this.dynamicModelRegistry = dynamicModelRegistry;
@@ -54,7 +54,7 @@ public class CustomVaultGearRegistryEntry extends ForgeRegistryEntry<CustomVault
         return dynamicModelRegistry;
     }
 
-    public Map<VaultGearRarity, List<String>> getModelRarityMap() {
+    public Map<String, List<String>> getModelRarityMap() {
         return modelRarityMap;
     }
 }

--- a/src/main/java/xyz/iwolfking/vhapi/mixin/registry/gear/MixinGearModelRollRaritiesConfig.java
+++ b/src/main/java/xyz/iwolfking/vhapi/mixin/registry/gear/MixinGearModelRollRaritiesConfig.java
@@ -32,7 +32,7 @@ public abstract class MixinGearModelRollRaritiesConfig extends Config {
     @Shadow @Nullable protected abstract VaultGearRarity getForcedTierRarity(ItemStack stack, ResourceLocation modelId);
 
     @Inject(method = "getRolls", at = @At("HEAD"), cancellable = true)
-    private void getRollsHook(CallbackInfoReturnable<Map<VaultGearRarity, List<String>>> cir, @Local ItemStack stack) {
+    private void getRollsHook(CallbackInfoReturnable<Map<String, List<String>>> cir, @Local ItemStack stack) {
         if(CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.containsKey(stack.getItem().getRegistryName())) {
             cir.setReturnValue(CustomGearModelRolls.CUSTOM_MODEL_ROLLS_MAP.get(stack.getItem().getRegistryName()));
         }


### PR DESCRIPTION
By changing the custom model roll map to use a string key instead of the `VaultGearRarity` type it allows the `getRolls` code to correctly match the rarity type otherwise it's just falling back to rolling all models as it can't find a match.